### PR TITLE
Add the documentation link to the dashboard

### DIFF
--- a/code/frontend/src/layouts/dashboard/nav/index.js
+++ b/code/frontend/src/layouts/dashboard/nav/index.js
@@ -103,7 +103,7 @@ export default function Nav({ openNav, onCloseNav }) {
           </Box>
 
           <Button
-            href="https://material-ui.com/store/items/minimal-dashboard/"
+            href="https://cepdnaclk.github.io/e18-3yp-smart-pet-collar/"
             target="_blank"
             variant="contained"
           >


### PR DESCRIPTION
In the frontend, there has a documentation button. We need to connect with this button to the our project page. The purpose of this button is to give proper idea about our product. 